### PR TITLE
Removed Tizen from build targets

### DIFF
--- a/Assets/Editor/CrossPlatformInput/CrossPlatformInputInitialize.cs
+++ b/Assets/Editor/CrossPlatformInput/CrossPlatformInputInitialize.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using UnityEditor;
 
@@ -35,7 +34,6 @@ namespace UnityStandardAssets.CrossPlatformInput.Inspector
                 //case BuildTarget.WP8Player:
                 //case BuildTarget.BlackBerry:
 				//case BuildTarget.PSM: 
-				case BuildTarget.Tizen: 
 				case BuildTarget.WSAPlayer: 
                     EditorUtility.DisplayDialog("Mobile Input",
                                                 "You have enabled Mobile Input. You'll need to use the Unity Remote app on a connected device to control your game in the Editor.",
@@ -85,8 +83,7 @@ namespace UnityStandardAssets.CrossPlatformInput.Inspector
         }
 
 
-        private static BuildTargetGroup[] buildTargetGroups = new BuildTargetGroup[]
-            {
+        private static BuildTargetGroup[] buildTargetGroups = {
                 BuildTargetGroup.Standalone,
                 //BuildTargetGroup.WebPlayer,
                 BuildTargetGroup.Android,
@@ -95,14 +92,12 @@ namespace UnityStandardAssets.CrossPlatformInput.Inspector
                 //BuildTargetGroup.BlackBerry
             };
 
-        private static BuildTargetGroup[] mobileBuildTargetGroups = new BuildTargetGroup[]
-            {
+        private static BuildTargetGroup[] mobileBuildTargetGroups = {
                 BuildTargetGroup.Android,
                 BuildTargetGroup.iOS,
                 //BuildTargetGroup.WP8,
                 //BuildTargetGroup.BlackBerry,
 				//BuildTargetGroup.PSM, 
-				BuildTargetGroup.Tizen, 
 				BuildTargetGroup.WSA 
             };
 


### PR DESCRIPTION
As of October 2018, Unity no longer supports Tizen.